### PR TITLE
Build infocenter-app with maven-war-plugin 3.3.2

### DIFF
--- a/infocenter-web/infocenter-app/pom.xml
+++ b/infocenter-web/infocenter-app/pom.xml
@@ -37,7 +37,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.3.2</version>
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
It has one less CVE from dependencies compared to version 3.3.1 used
now.
https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-war-plugin/3.3.2
https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-war-plugin/3.3.1