### PR TITLE
Modernized help UI prototype: do not convert search string to lower case

### DIFF
--- a/org.eclipse.help.webapp/m/index.js
+++ b/org.eclipse.help.webapp/m/index.js
@@ -1146,7 +1146,7 @@
                 }
             }
             var query = searchWord.length
-                        ? (  encodeURIComponent(searchWord.toLowerCase())
+                        ? (  encodeURIComponent(searchWord)
                            + ((searchScope.l == 1 || searchScope.l == 2) && tocScope && tocScope.toc ? '&toc=' + encodeURIComponent(tocScope.toc) : '')
                            + (searchScope.l == 2 && tocScope && tocScope.path ? '&path=' + tocScope.path : '')
                            + (searchScope.l == 4 && searchScope.s ? '&scope=' + encodeURIComponent(searchScope.s) : ''))


### PR DESCRIPTION
In the past, queries has been converted to lower case for performance
reasons (to need only a single request for multiple queries that differ
only in case). This has been done based on the false assumption that
this will have no effect to the search results. But in some cases,
converting the search string to lower case affects the results.

For example, "EvaluationResult.NOT_LOADED" vs.
"evaluationresult.not_loaded" (both without quotes) leads to
different search results (current number of hits in parentheses; please
note that the search term is converted to lower case when entered in the
search field of the modernized UI, but not when given as URL parameter #q=...):
https://help.eclipse.org/latest/index.jsp?tab=search&searchWord=EvaluationResult.NOT_LOADED (38)
vs.
https://help.eclipse.org/latest/index.jsp?tab=search&searchWord=evaluationresult.not_loaded (0)