### PR TITLE
Update to Jetty 10.0.9

### DIFF
--- a/org.eclipse.help.webapp/pom.xml
+++ b/org.eclipse.help.webapp/pom.xml
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jspc-maven-plugin</artifactId>
-        <version>10.0.8</version>
+        <version>10.0.9</version>
         <executions>
           <execution>
             <id>jspc</id>


### PR DESCRIPTION
Use that version of jetty-jspc-maven-plugin.
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/187