### PR TITLE
Fix help webapp compiling JSPs when run on Java 17+

### DIFF
--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.test
  org.eclipse.help.webapp
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0"
+ javax.servlet.http;version="3.1.0",
+ org.eclipse.jdt.core.compiler
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.help.webapp

--- a/org.eclipse.ua.tests/pom.xml
+++ b/org.eclipse.ua.tests/pom.xml
@@ -42,11 +42,6 @@
 	            </requirement>
 	            <requirement>
 	              <type>eclipse-plugin</type>
-	              <id>org.eclipse.jdt.core</id>
-	              <versionRange>0.0.0</versionRange>
-	            </requirement>
-	            <requirement>
-	              <type>eclipse-plugin</type>
 	              <id>org.eclipse.help.ui</id>
 	              <versionRange>0.0.0</versionRange>
 	            </requirement>


### PR DESCRIPTION
Jasper shipped embeds ancient version of ecj which doesn't support
targeting newer Java versions. As Eclipse is the author of ecj it makes
sense to include our own version which is the absolute latest one.
Removed workaround in tests explicitly adding jdt.core that is no longer
needed
Fixes https://github.com/eclipse-platform/eclipse.platform.ua/issues/18