### PR TITLE
Revert "Fix help webapp compiling JSPs when run on Java 17+"

### DIFF
--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.test
  org.eclipse.help.webapp
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0",
- org.eclipse.jdt.core.compiler
+ javax.servlet.http;version="3.1.0"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.help.webapp

--- a/org.eclipse.ua.tests/pom.xml
+++ b/org.eclipse.ua.tests/pom.xml
@@ -42,6 +42,11 @@
 	            </requirement>
 	            <requirement>
 	              <type>eclipse-plugin</type>
+	              <id>org.eclipse.jdt.core</id>
+	              <versionRange>0.0.0</versionRange>
+	            </requirement>
+	            <requirement>
+	              <type>eclipse-plugin</type>
 	              <id>org.eclipse.help.ui</id>
 	              <versionRange>0.0.0</versionRange>
 	            </requirement>


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.ua#20 as it breaks I-build with:
```
15:37:05  [ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:3.0.0-SNAPSHOT:validate-classpath (default-validate-classpath) on project org.eclipse.help.webapp: Execution default-validate-classpath of goal org.eclipse.tycho:tycho-compiler-plugin:3.0.0-SNAPSHOT:validate-classpath failed: org.osgi.framework.BundleException: Bundle org.eclipse.help.webapp cannot be resolved:org.eclipse.help.webapp [36]
15:37:05  [ERROR]   Unresolved requirement: Import-Package: org.eclipse.jdt.core.compiler
15:37:05  [ERROR]     -> Export-Package: org.eclipse.jdt.core.compiler; bundle-symbolic-name="org.eclipse.jdt.core"; bundle-version="3.30.100.qualifier"; version="0.0.0"
15:37:05  [ERROR]        org.eclipse.jdt.core [37]
15:37:05  [ERROR]          Unresolved requirement: Require-Bundle: org.eclipse.core.resources; bundle-version="[3.17.0,4.0.0)"
```