### PR TITLE
Modernized help UI prototype: Fix "Print topic..." in Internet Explorer

### DIFF
--- a/org.eclipse.help.webapp/m/index.js
+++ b/org.eclipse.help.webapp/m/index.js
@@ -2147,9 +2147,10 @@
         // "Print topic..."
         createMenuItem('<%js:menu_item_print_topic_label%>', '<%js:menu_item_print_topic_description%>', function() {
             try {
-                getElementById('c').contentWindow.print();
-            } catch (e) {
-            }
+                var toPrint = getElementById('c').contentWindow;
+                toPrint.focus(); // required for Internet Explorer to print not only the first page
+                toPrint.print();
+            } catch (e) {}
         }, 'ap');
 
         // "Print chapter..."


### PR DESCRIPTION
When using the Modernized help UI prototype, on Windows, in the _Help_ window (_Help > Help Contents_) which uses the Internet Explorers, _Print topic..._ should print not only the first page, but all pages of the topic.

**Problem:**
In the Internet Explorer [`print()`](https://www.w3schools.com/jsref/met_win_print.asp) for an iframe prints only the first page when the focus is not set into the iframe.