### PR TITLE
Bug 202691 - [Cheatsheets] Edit->Copy and Ctrl+C do not copy selectedtext

### DIFF
--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
@@ -1292,8 +1292,12 @@ public class CheatSheetViewer implements ICheatSheetViewer, IMenuContributor {
 	}
 
 	public void copy() {
-		if (currentItem!=null)
-			currentItem.copy();
+		for (ViewItem viewItem : viewItemList) {
+			if (viewItem.hasFocus()) {
+				viewItem.copy();
+				return;
+			}
+		}
 	}
 
 	public void addListener(CheatSheetListener listener) {

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/ViewItem.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/ViewItem.java
@@ -636,4 +636,8 @@ public abstract class ViewItem {
 
 	abstract boolean hasCompletionMessage();
 
+	boolean hasFocus() {
+		return bodyText.isFocusControl();
+	}
+
 }


### PR DESCRIPTION
Fixes Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=202691

The Copy action tried to always copy from the "current item" even when this was not the selected item.
The change checks for the first item with focus (which should be only one item) and executes the copy on that item.