### PR TITLE
Make webapp use precompiled jsp files.

### DIFF
--- a/org.eclipse.help.webapp/pom.xml
+++ b/org.eclipse.help.webapp/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2019 Eclipse Foundation.
+  Copyright (c) 2012, 2022 Eclipse Foundation.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -33,9 +33,6 @@
               <goal>jspc</goal>
             </goals>
             <configuration>
-              <jspc>
-                <package>org.eclipse.help.internal.webapp.jsp</package>
-              </jspc>
               <webAppSourceDirectory>${basedir}</webAppSourceDirectory>
               <useProvidedScope>true</useProvidedScope>
               <sourceVersion>11</sourceVersion>


### PR DESCRIPTION
JSPc is configured to put class files in
org.eclipse.help.internal.webapp.jsp package but in order for these
class files to be used the following config is needed:
```
  <context-param>
    <param-name>org.eclipse.jetty.servlet.jspPackagePrefix</param-name>
    <param-value>com.acme</param-value>
  </context-param>
```
as per https://www.eclipse.org/jetty/documentation/jetty-9/index.html#jetty-jspc-maven-plugin
.
As this is not set and rightfully so cause that would require every help
plugin shipping *.jsp files to compile into
org.eclipse.help.internal.webapp.jsp package at runtime Jetty recompiles
them into org.apache.jsp package and uses these classes.
Furthermore (Jetty 10
docs)[https://www.eclipse.org/jetty/documentation/jetty-10/operations-guide/index.html#og-jsp]
doesn't mention jspPackagePrefix.
Thus this patch removes the jsp compiler package instruction so the
default package name is used and thus should be loaded from the jar file
rather than generated at runtime.