### PR TITLE
Add "import org.apache.commons.fileupload" to org.eclipse.ua.tests

### DIFF
--- a/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.junit,
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0"
+ javax.servlet.http;version="3.1.0",
+ org.apache.commons.fileupload;version="1.3.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.ua.tests,
  org.eclipse.ua.tests.browser.servlet,


### PR DESCRIPTION
org.eclipse.equinox.http.servlet needs this package but it is marked as
optional so probably not added to the test runtime dependencies.

See https://github.com/eclipse-platform/eclipse.platform.ua/issues/42