### PR TITLE
Add "import org.apache.commons.fileupload" to org.eclipse.ua.tests.doc

### DIFF
--- a/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ua.tests.doc;singleton:=true
-Bundle-Version: 1.1.300.qualifier
+Bundle-Version: 1.1.400.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.equinox.http.registry;bundle-version="1.0.200",
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0"
+ javax.servlet.http;version="3.1.0",
+ org.apache.commons.fileupload;version="1.3.2"
 Export-Package: org.eclipse.ua.tests.doc,
  org.eclipse.ua.tests.doc.internal;x-internal:=true,
  org.eclipse.ua.tests.doc.internal.actions;x-internal:=true,

--- a/org.eclipse.ua.tests.doc/pom.xml
+++ b/org.eclipse.ua.tests.doc/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ua</groupId>
   <artifactId>org.eclipse.ua.tests.doc</artifactId>
-  <version>1.1.300-SNAPSHOT</version>
+  <version>1.1.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
org.eclipse.equinox.http.servlet needs this package but it is marked as
optional so probably not added to the test runtime dependencies.

See https://github.com/eclipse-platform/eclipse.platform.ua/issues/42