### PR TITLE
Remove "import org.apache.commons.fileupload" from org.eclipse.ua.tests*

### DIFF
--- a/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
@@ -15,8 +15,7 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0",
- org.apache.commons.fileupload;version="1.3.2"
+ javax.servlet.http;version="3.1.0"
 Export-Package: org.eclipse.ua.tests.doc,
  org.eclipse.ua.tests.doc.internal;x-internal:=true,
  org.eclipse.ua.tests.doc.internal.actions;x-internal:=true,

--- a/org.eclipse.ua.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ua.tests/META-INF/MANIFEST.MF
@@ -27,8 +27,7 @@ Require-Bundle: org.junit,
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org
 Import-Package: javax.servlet;version="3.1.0",
- javax.servlet.http;version="3.1.0",
- org.apache.commons.fileupload;version="1.3.2"
+ javax.servlet.http;version="3.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.ua.tests,
  org.eclipse.ua.tests.browser.servlet,


### PR DESCRIPTION
SDK help does NOT need this package (it is marked as optional) so we
don't need that either here. It was added before based on wrong
assumption that it's the test only requirement.
It turned out, it was a regression in equinox.

See https://github.com/eclipse-platform/eclipse.platform.ua/issues/42
and https://github.com/eclipse-equinox/equinox/issues/88