### PR TITLE
Remove org.eclipse.pde.ds.lib/annotations.jar from extra classpath

### DIFF
--- a/org.eclipse.tips.ide/build.properties
+++ b/org.eclipse.tips.ide/build.properties
@@ -21,4 +21,3 @@ bin.includes = META-INF/,\
                images/,\
                about.html
 src.includes = about.html
-jars.extra.classpath = platform:/plugin/org.eclipse.pde.ds.lib/annotations.jar


### PR DESCRIPTION
This is obsolete now