### PR TITLE
Fix JSP compilation on Java 17+

### DIFF
--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help.base;bundle-version="[4.3.200,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100"
+ org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100",
+ org.eclipse.jdt.core.compiler.batch
 Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.data;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.parser;x-internal:=true,


### PR DESCRIPTION
Add hard require on o.e.jdt.core for this to work as jasper version shipped is too old to support that.
Jasper includes in-jar copy of old version of jdt so this is not new dependency but rather overriding ancient version shipped. Fixes https://github.com/eclipse-platform/eclipse.platform.ua/issues/18