### PR TITLE
Yet another try to fix jsp compilation on Java 17+

### DIFF
--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help.base;bundle-version="[4.3.200,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100",
- org.eclipse.jdt.core.compiler.batch
+ org.eclipse.jdt.core
 Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.data;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.parser;x-internal:=true,


### PR DESCRIPTION
Switch required bundle to org.eclipse.jdt.core as
org.eclipse.jdt.core.compiler.batch is artificial one created by Ant during the build and thus Maven/Tycho can't resolve it.

Hoping that https://github.com/eclipse-platform/eclipse.platform.ua/issues/18 works with this one.