### PR TITLE
Switch help.webapp to use jdt.core.compiler.batch

### DIFF
--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help.base;bundle-version="[4.3.200,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100",
- org.eclipse.jdt.core
+ org.eclipse.jdt.core.compiler.batch
 Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.data;x-friends:="org.eclipse.ua.tests",
  org.eclipse.help.internal.webapp.parser;x-internal:=true,


### PR DESCRIPTION
With https://github.com/eclipse-jdt/eclipse.jdt.core/issues/181 compiler is extracted into its own bundle so help webapp can depend on it only without bringing the extra deps.