### PR TITLE
Stop stop mangling root based on bot user agent

### DIFF
--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/data/RequestData.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/data/RequestData.java
@@ -55,10 +55,6 @@ public class RequestData {
 		return preferences;
 	}
 
-	public boolean isBot() {
-		return UrlUtil.isBot(request);
-	}
-
 	public boolean isGecko() {
 		return UrlUtil.isGecko(request);
 	}

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/data/UrlUtil.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/data/UrlUtil.java
@@ -260,16 +260,6 @@ public class UrlUtil {
 		}
 	}
 
-	public static boolean isBot(HttpServletRequest request) {
-		String agent = request.getHeader("User-Agent"); //$NON-NLS-1$
-		if (agent==null)
-			return false;
-		agent=agent.toLowerCase(Locale.ENGLISH);
-		// sample substring Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
-		return agent.contains("bot") || agent.contains("crawl")//$NON-NLS-1$ //$NON-NLS-2$
-				|| request.getParameter("bot") != null;//$NON-NLS-1$
-	}
-
 	public static boolean isGecko(HttpServletRequest request) {
 		String agent = request.getHeader("User-Agent"); //$NON-NLS-1$
 		return isGecko(agent);

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/BreadcrumbsFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/BreadcrumbsFilter.java
@@ -49,9 +49,7 @@ public class BreadcrumbsFilter implements IFilter {
 		if ("/rtopic".equals(req.getServletPath()) || "/nftopic".equals(req.getServletPath())) { //$NON-NLS-1$ //$NON-NLS-2$
 			return out;
 		}
-		if (UrlUtil.isBot(req)) {
-			return out;
-		}
+
 		if ("true".equals(req.getParameter("noframes"))) {  //$NON-NLS-1$//$NON-NLS-2$
 			return out;
 		}

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FramesetFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/FramesetFilter.java
@@ -49,8 +49,7 @@ public class FramesetFilter implements IFilter {
 
 		if ("/nftopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
 			"/ntopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
-			"/rtopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
-			UrlUtil.isBot(req)) {
+			"/rtopic".equals(req.getServletPath()) ) { //$NON-NLS-1$
 			return out;
 		}
 

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/InjectionFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/InjectionFilter.java
@@ -26,7 +26,6 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.help.internal.base.HelpBasePlugin;
 import org.eclipse.help.internal.util.ProductPreferences;
 import org.eclipse.help.internal.webapp.data.CssUtil;
-import org.eclipse.help.internal.webapp.data.UrlUtil;
 import org.eclipse.help.webapp.IFilter;
 
 /**
@@ -61,9 +60,7 @@ public class InjectionFilter implements IFilter {
 		if (uri == null || !uri.endsWith("html") && !uri.endsWith("htm") && !isNav) { //$NON-NLS-1$ //$NON-NLS-2$
 			return out;
 		}
-		if (UrlUtil.isBot(req)) {
-			return out;
-		}
+
 		String pathInfo = req.getPathInfo();
 		if (pathInfo == null) {
 			return out;

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/ShowInTocFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/ShowInTocFilter.java
@@ -39,8 +39,7 @@ public class ShowInTocFilter implements IFilter {
 
 		if ("/nftopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
 			"/ntopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
-			"/rtopic".equals(req.getServletPath()) ||  //$NON-NLS-1$
-			UrlUtil.isBot(req)) {
+			"/rtopic".equals(req.getServletPath()) ) {  //$NON-NLS-1$
 			return out;
 		}
 


### PR DESCRIPTION
Removes the logic in infocentre to use the user agent to provide different contents to the client depending on whether it is a bot or not. See the following helpdesk issues which are side effects of this:

https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2298 https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2160 https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2326

Fixes code part of
https://github.com/eclipse-platform/eclipse.platform/issues/557