### PR TITLE
Fix running tests on Jenkins

### DIFF
--- a/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/TestServerManager.java
+++ b/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/remote/TestServerManager.java
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.CoreException;
 public class TestServerManager {
 
 	private static JettyTestServer[] server = new JettyTestServer[2];
-	private static boolean serverRunning[] = new boolean[] { false, false };
+	private static boolean serverRunning[] = { false, false };
 
 	private static JettyTestServer getHelpServer(int index) {
 		if (server[index] == null) {

--- a/org.eclipse.ua.tests/pom.xml
+++ b/org.eclipse.ua.tests/pom.xml
@@ -42,11 +42,6 @@
 	            </requirement>
 	            <requirement>
 	              <type>eclipse-plugin</type>
-	              <id>org.eclipse.jdt.core</id>
-	              <versionRange>0.0.0</versionRange>
-	            </requirement>
-	            <requirement>
-	              <type>eclipse-plugin</type>
 	              <id>org.eclipse.help.ui</id>
 	              <versionRange>0.0.0</versionRange>
 	            </requirement>
@@ -60,6 +55,16 @@
 	              <id>org.eclipse.platform</id>
 	              <versionRange>0.0.0</versionRange>
 	            </requirement>
+	             <requirement>
+	              <type>eclipse-plugin</type>
+	              <id>org.eclipse.jdt.core.compiler.batch</id>
+	              <versionRange>0.0.0</versionRange>
+	            </requirement>
+				<requirement>
+					<type>eclipse-plugin</type>
+					<id>org.apache.jasper.glassfish</id>
+					<versionRange>0.0.0</versionRange>
+				</requirement>
 	          </extraRequirements>
 	      </dependency-resolution>
         </configuration>


### PR DESCRIPTION
Ensuring that both jasper (for JspC) and jdt.core.compiler.batch (for actual java compiler) are in the target platform is needed.