### PR TITLE
Fix master build

### DIFF
--- a/org.eclipse.ua.tests.doc/pom.xml
+++ b/org.eclipse.ua.tests.doc/pom.xml
@@ -67,6 +67,11 @@
 	            </requirement>
 	            <requirement>
 	              <type>eclipse-plugin</type>
+	              <id>org.eclipse.ui.cheatsheets</id>
+	              <versionRange>0.0.0</versionRange>
+	            </requirement>
+	            <requirement>
+	              <type>eclipse-plugin</type>
 	              <id>org.eclipse.help.ui</id>
 	              <versionRange>0.0.0</versionRange>
 	            </requirement>


### PR DESCRIPTION
As can be seen at
https://ci.eclipse.org/platform/job/eclipse.platform.ua/job/master/109/console :
```
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: org.eclipse.jdt.feature.group
3.19.0.v20230205-1800
[ERROR]   Missing requirement: org.eclipse.jdt 3.19.0.v20230204-1800
requires 'osgi.bundle; org.eclipse.ui.cheatsheets [3.2.0,4.0.0)' but it
could not be found
[ERROR]   Missing requirement: org.eclipse.jdt 3.19.0.v20230205-1800
requires 'osgi.bundle; org.eclipse.ui.cheatsheets [3.2.0,4.0.0)' but it
could not be found
[ERROR]   Cannot satisfy dependency: org.eclipse.jdt.feature.group
3.19.0.v20230204-1955 depends on: org.eclipse.equinox.p2.iu;
org.eclipse.jdt [3.19.0.v20230204-1800,3.19.0.v20230204-1800]
[ERROR]   Cannot satisfy dependency: org.eclipse.jdt.feature.group
3.19.0.v20230205-1800 depends on: org.eclipse.equinox.p2.iu;
org.eclipse.jdt [3.19.0.v20230205-1800,3.19.0.v20230205-1800]

```