### PR TITLE
meta: update jetty version

### DIFF
--- a/org.eclipse.help.webapp/pom.xml
+++ b/org.eclipse.help.webapp/pom.xml
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jspc-maven-plugin</artifactId>
-        <version>9.4.48.v20220622</version>
+        <version>9.4.51.v20230217</version>
         <executions>
           <execution>
             <id>jspc</id>


### PR DESCRIPTION
Refs: https://github.com/eclipse/jetty.project/security/advisories/GHSA-p26g-97m4-6q7c

/cc @sravanlakkimsetti