### PR TITLE
Clean-up OSGi package imports

### DIFF
--- a/org.eclipse.tips.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.tips.examples/META-INF/MANIFEST.MF
@@ -12,5 +12,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.0.0",
  org.eclipse.e4.core.commands;bundle-version="0.1.0",
  org.eclipse.ui;bundle-version="3.0.0"
 Eclipse-BundleShape: dir
-Import-Package: org.osgi.framework;version="1.8.0"
+Import-Package: org.osgi.framework;version="[1.8.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.tips.examples

--- a/org.eclipse.tips.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.tips.ide/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.0.0",
  org.eclipse.tips.ui;bundle-version="0.1.0",
  org.eclipse.tips.json
 Import-Package: javax.annotation,
- org.osgi.service.event;version="1.4.0"
+ org.osgi.service.event;version="[1.4.0,2.0.0)"
 Export-Package: org.eclipse.tips.ide.internal;x-internal:=true
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.tips.ide/build.properties
+++ b/org.eclipse.tips.ide/build.properties
@@ -21,5 +21,3 @@ bin.includes = META-INF/,\
                images/,\
                about.html
 src.includes = about.html
-# Only required for dev/build, not runtime
-additional.bundles = org.osgi.service.component.annotations

--- a/org.eclipse.ui.intro.quicklinks/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.intro.quicklinks/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui.intro;bundle-version="3.4.0",
  org.eclipse.jface;bundle-version="3.12.0",
  org.eclipse.ui.forms;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.12.0"
-Import-Package: org.osgi.framework;version="1.8.0"
+Import-Package: org.osgi.framework;version="[1.8.0,2.0.0)"
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.ui.intro.quicklinks;version="1.0.0"


### PR DESCRIPTION
- Use properly closed version range
- Remove unnecessary imports of org.osgi.service.component.annotations (they are only necessary at compile-time and Tycho adds them for compilation on the fly).