### PR TITLE
Improve OSGi metadata about dependency to javax.inject/annotations

### DIFF
--- a/org.eclipse.tips.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.tips.ide/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.0.0",
  org.eclipse.tips.core;bundle-version="0.1.0",
  org.eclipse.tips.ui;bundle-version="0.1.0",
  org.eclipse.tips.json
-Import-Package: javax.annotation,
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
  org.osgi.service.event;version="[1.4.0,2.0.0)"
 Export-Package: org.eclipse.tips.ide.internal;x-internal:=true
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -27,8 +27,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.e4.ui.model.workbench
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation,
- javax.inject,
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)",
  javax.xml.parsers,
  javax.xml.transform,
  javax.xml.transform.dom,


### PR DESCRIPTION
- Always use closed version ranges [1.X,2) with a minor lower bound

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056