### PR TITLE
Restore required bundle o.e.core.expressions of o.e.ui.intro

### DIFF
--- a/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.help.base;bundle-version="[4.0.0,5.0.0)";resolution:=optional,
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.expressions;bundle-version="3.4.200",
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.model.workbench
 Eclipse-LazyStart: true


### PR DESCRIPTION
It was removed in PR https://github.com/eclipse-platform/eclipse.platform.ua/pull/19 because it is transitively available, since o.e.core.expressions is reexported by o.e.help, which is rexported by o.e.help.base, which is required by o.e.ui.intro. But the requirement of o.e.ui.intro for o.e.help.base is only optional and therefore the help bundles can be absent, which leads to class-loading errors when loading classes from o.e.core.expressions.

Restoring the requirement for o.e.core.expressions fixes this problem.

Fixes https://github.com/eclipse-platform/eclipse.platform.ua/issues/122