### PR TITLE
Random failures in LinkTest (#130)

### DIFF
--- a/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.ua.tests.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ua.tests.doc;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.equinox.http.registry;bundle-version="1.0.200",

--- a/org.eclipse.ua.tests.doc/pom.xml
+++ b/org.eclipse.ua.tests.doc/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ua</groupId>
   <artifactId>org.eclipse.ua.tests.doc</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Don't hide exceptions on resolving, fail test with the first one (otherwise test fails later with obscure NP exceptions).

This should help to understand why test fails randomly, but does not fix the test yet.

See https://github.com/eclipse-platform/eclipse.platform.ua/issues/130