### PR TITLE
Don't include a specific version of gson

### DIFF
--- a/org.eclipse.tips.feature/feature.xml
+++ b/org.eclipse.tips.feature/feature.xml
@@ -60,11 +60,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="com.google.gson"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
The  org.eclipse.tips.json bundle allows a range:

Import-Package: com.google.gson;version="[2.8.6,3.0.0)"

https://github.com/eclipse-platform/eclipse.platform.releng/issues/230