### PR TITLE
LinkTest: fix NPE due to concurrent use of TreeMap #155

### DIFF
--- a/org.eclipse.ua.tests.doc/src/org/eclipse/ua/tests/doc/internal/linkchecker/LinkTest.java
+++ b/org.eclipse.ua.tests.doc/src/org/eclipse/ua/tests/doc/internal/linkchecker/LinkTest.java
@@ -78,7 +78,7 @@ public class LinkTest {
 
 		Set<String> linkFailures = Collections.synchronizedSet(new TreeSet<>());
 		Set<Exception> ex = Collections.synchronizedSet(new LinkedHashSet<>());
-		Set<URI> allKnownPageURIs = new TreeSet<>(indexedPagesURIs);
+		Set<URI> allKnownPageURIs = Collections.synchronizedSet(new TreeSet<>(indexedPagesURIs));
 		indexedPagesURIs.parallelStream().forEach(t -> {
 			String path = t.getPath();
 			if (path.lastIndexOf('/') > 0) {


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.ua/issues/155