### PR TITLE
Use new static IPath factories and constants

### DIFF
--- a/org.eclipse.help.base/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.base/META-INF/MANIFEST.MF
@@ -40,7 +40,7 @@ Export-Package: org.apache.lucene.demo.html;x-internal:=true,
  org.eclipse.help.server,
  org.eclipse.help.standalone
 Require-Bundle: org.eclipse.ant.core;bundle-version="[3.2.200,4.0.0)";resolution:=optional,
- org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.net;bundle-version="[1.2.200,2.0.0]",
  org.apache.lucene.analysis-common;bundle-version="[9.4.2,10.0.0)",

--- a/org.eclipse.help.base/src/org/eclipse/help/internal/search/LocalSearchManager.java
+++ b/org.eclipse.help.base/src/org/eclipse/help/internal/search/LocalSearchManager.java
@@ -34,10 +34,10 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.IHelpResource;
 import org.eclipse.help.internal.HelpPlugin;
@@ -130,7 +130,7 @@ public class LocalSearchManager {
 			Bundle bundle = Platform.getBundle(bundleId);
 			if (bundle == null)
 				return null;
-			return FileLocator.find(bundle, new Path(relativePath), null);
+			return FileLocator.find(bundle, IPath.fromOSString(relativePath), null);
 		}
 
 		public void clear() {

--- a/org.eclipse.help.base/src/org/eclipse/help/internal/search/PluginIndex.java
+++ b/org.eclipse.help.base/src/org/eclipse/help/internal/search/PluginIndex.java
@@ -26,7 +26,6 @@ import java.util.Properties;
 import org.apache.lucene.util.Version;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.base.util.ProxyUtil;
 import org.eclipse.help.internal.util.ResourceLocator;
@@ -78,7 +77,7 @@ public class PluginIndex {
 		ArrayList<String> availablePrefixes = ResourceLocator.getPathPrefix(targetIndex
 				.getLocale());
 		for (String prefix : availablePrefixes) {
-			IPath prefixedPath = new Path(prefix + path);
+			IPath prefixedPath = IPath.fromOSString(prefix + path);
 			// find index at this directory in plugin or fragments
 			URL url = FileLocator.find(bundle, prefixedPath, null);
 			if (url == null) {

--- a/org.eclipse.help.base/src/org/eclipse/help/internal/search/XHTMLSearchParticipant.java
+++ b/org.eclipse.help.base/src/org/eclipse/help/internal/search/XHTMLSearchParticipant.java
@@ -16,7 +16,6 @@ package org.eclipse.help.internal.search;
 import java.io.InputStream;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.xhtml.DynamicXHTMLProcessor;
 import org.eclipse.help.search.SearchParticipantXML;
@@ -73,7 +72,7 @@ public class XHTMLSearchParticipant extends SearchParticipantXML {
 	@Override
 	protected void handleText(String text, IParsedXMLContent data) {
 		String stackPath = getElementStackPath();
-		IPath path = new Path(stackPath);
+		IPath path = IPath.fromOSString(stackPath);
 		if (path.segment(1).equalsIgnoreCase("body") &&  //$NON-NLS-1$
 			!isSkipped(path.segment(path.segmentCount() -1))) {
 			data.addText(text);

--- a/org.eclipse.help.base/src/org/eclipse/help/search/SearchParticipant.java
+++ b/org.eclipse.help.base/src/org/eclipse/help/search/SearchParticipant.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.util.ResourceLocator;
 import org.osgi.framework.Bundle;
@@ -149,8 +149,8 @@ public abstract class SearchParticipant {
 		Bundle bundle = Platform.getBundle(pluginId);
 		if (bundle == null)
 			return fileName;
-		URL url = ResourceLocator.find(bundle, new Path(fileName), prefix);
-		URL root = FileLocator.find(bundle, new Path(""), null); //$NON-NLS-1$
+		URL url = ResourceLocator.find(bundle, IPath.fromOSString(fileName), prefix);
+		URL root = FileLocator.find(bundle, IPath.EMPTY, null); // $NON-NLS-1$
 		return url.toString().substring(root.toString().length());
 	}
 

--- a/org.eclipse.help.base/src_ant/org/eclipse/help/internal/base/ant/BuildHelpIndex.java
+++ b/org.eclipse.help.base/src_ant/org/eclipse/help/internal/base/ant/BuildHelpIndex.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.help.search.HelpIndexBuilder;
 
 /**
@@ -84,7 +83,7 @@ public class BuildHelpIndex extends Task {
 	private File getFile(String fileName) {
 		if (fileName == null)
 			return null;
-		IPath path = new Path(fileName);
+		IPath path = IPath.fromOSString(fileName);
 		if (path.isAbsolute())
 			return new File(fileName);
 		File root = getProject().getBaseDir();

--- a/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.5.100.qualifier
+Bundle-Version: 4.6.0.qualifier
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -19,7 +19,7 @@ Export-Package: org.eclipse.help.ui,
  org.eclipse.help.ui.internal.views;x-friends:="org.eclipse.ui.cheatsheets,org.eclipse.ua.tests"
 Require-Bundle: org.eclipse.help.base;bundle-version="[4.0.0,5.0.0)";visibility:=reexport,
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)";visibility:=reexport,
- org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)";visibility:=reexport,
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)";visibility:=reexport,
  org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)"
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/HelpUIResources.java
+++ b/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/HelpUIResources.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
@@ -51,7 +50,7 @@ public class HelpUIResources {
 	 * Returns a string from a property file
 	 */
 	public static URL getImagePath(String name) {
-		IPath path = new Path("$nl$/icons/").append(name); //$NON-NLS-1$
+		IPath path = IPath.fromOSString("$nl$/icons/").append(name); //$NON-NLS-1$
 		return FileLocator.find(HelpUIPlugin.getDefault().getBundle(), path, null);
 	}
 
@@ -78,7 +77,7 @@ public class HelpUIResources {
 		if (desc==null) {
 			Bundle bundle = Platform.getBundle(bundleId);
 			if (bundle==null) return null;
-			URL url = FileLocator.find(bundle, new Path(name), null);
+			URL url = FileLocator.find(bundle, IPath.fromOSString(name), null);
 			desc = ImageDescriptor.createFromURL(url);
 			registry.put(name, desc);
 		}
@@ -91,7 +90,7 @@ public class HelpUIResources {
 		if (desc==null) {
 			Bundle bundle = Platform.getBundle(bundleId);
 			if (bundle == null) return null;
-			URL url = FileLocator.find(bundle, new Path(path), null);
+			URL url = FileLocator.find(bundle, IPath.fromOSString(path), null);
 			desc = ImageDescriptor.createFromURL(url);
 			registry.put(key, desc);
 		}

--- a/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
+++ b/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
@@ -21,8 +21,8 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -437,8 +437,7 @@ public class EmbeddedBrowser {
 					if (product != null) {
 						Bundle productBundle = product.getDefiningBundle();
 						if (productBundle != null) {
-							imageURL = FileLocator.find(productBundle, new Path(
-									productImageURLs[i]), null);
+							imageURL = FileLocator.find(productBundle, IPath.fromOSString(productImageURLs[i]), null);
 						}
 					}
 				}

--- a/org.eclipse.help.webapp/META-INF/MANIFEST.MF
+++ b/org.eclipse.help.webapp/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.eclipse.help.internal.webapp.HelpWebappPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help.base;bundle-version="[4.3.200,5.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.equinox.jsp.jasper.registry;bundle-version="1.0.100",
  org.eclipse.jdt.core.compiler.batch;bundle-version="[3.33.0,4.0.0)"
 Export-Package: org.eclipse.help.internal.webapp;x-friends:="org.eclipse.ua.tests",

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/BreadcrumbsFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/BreadcrumbsFilter.java
@@ -18,7 +18,7 @@ import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.ITopic;
 import org.eclipse.help.internal.HelpPlugin;
@@ -95,7 +95,7 @@ public class BreadcrumbsFilter implements IFilter {
 	}
 
 	private String getBackpath(String path) {
-		int num = new Path(path).segmentCount();
+		int num = IPath.fromOSString(path).segmentCount();
 		StringBuilder buf = new StringBuilder();
 		for (int i=0;i<num;++i) {
 			if (i > 0) {

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/ChildLinkInserter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/ChildLinkInserter.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.help.ITopic;
 import org.eclipse.help.base.AbstractHelpScope;
 import org.eclipse.help.internal.HelpPlugin;
@@ -106,7 +106,7 @@ public class ChildLinkInserter {
 	}
 
 	private String getBackpath(String path) {
-		int num = new Path(path).segmentCount() - 1;
+		int num = IPath.fromOSString(path).segmentCount() - 1;
 		StringBuilder buf = new StringBuilder();
 		for (int i=0; i < num; ++i) {
 			if (i > 0) {

--- a/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/InjectionFilter.java
+++ b/org.eclipse.help.webapp/src/org/eclipse/help/internal/webapp/servlet/InjectionFilter.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.help.internal.base.HelpBasePlugin;
 import org.eclipse.help.internal.util.ProductPreferences;
 import org.eclipse.help.internal.webapp.data.CssUtil;
@@ -96,7 +95,7 @@ public class InjectionFilter implements IFilter {
 		if (cssIncludes.isEmpty() && !addDisabled)
 			return out;
 
-		IPath path = new Path(pathInfo);
+		IPath path = IPath.fromOSString(pathInfo);
 		int upLevels = path.segmentCount() - 1;
 		String relativePath = FilterUtils.getRelativePathPrefix(req);
 		StringBuilder script = new StringBuilder();

--- a/org.eclipse.help/META-INF/MANIFEST.MF
+++ b/org.eclipse.help/META-INF/MANIFEST.MF
@@ -56,7 +56,7 @@ Export-Package: org.eclipse.help,
    org.eclipse.ua.tests,
    org.eclipse.ui.intro.universal,
    org.eclipse.ui.intro"
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.200,4.0.0)";visibility:=reexport
 Eclipse-LazyStart: true
 Import-Package: javax.xml.parsers,

--- a/org.eclipse.help/src/org/eclipse/help/internal/entityresolver/LocalEntityResolver.java
+++ b/org.eclipse.help/src/org/eclipse/help/internal/entityresolver/LocalEntityResolver.java
@@ -20,7 +20,7 @@ import java.io.StringReader;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.help.internal.HelpPlugin;
 import org.osgi.framework.Bundle;
 import org.xml.sax.EntityResolver;
@@ -35,7 +35,7 @@ public class LocalEntityResolver implements EntityResolver {
 		if (index >= 0) {
 			Bundle helpBundle = HelpPlugin.getDefault().getBundle();
 			String dtdPath = "dtds/internal" + systemId.substring(index); //$NON-NLS-1$
-			URL dtdURL = FileLocator.find(helpBundle, new Path(dtdPath), null);
+			URL dtdURL = FileLocator.find(helpBundle, IPath.fromOSString(dtdPath), null);
 			if (dtdURL != null) {
 				InputStream stream = dtdURL.openStream();
 				if (stream != null) {

--- a/org.eclipse.help/src/org/eclipse/help/internal/extension/ContentExtensionFileParser.java
+++ b/org.eclipse.help/src/org/eclipse/help/internal/extension/ContentExtensionFileParser.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.help.IUAElement;
 import org.eclipse.help.internal.UAElement;
 import org.eclipse.help.internal.dynamic.DocumentProcessor;
@@ -51,7 +51,7 @@ public class ContentExtensionFileParser extends DefaultHandler {
 		if (reader == null) {
 			reader = new DocumentReader();
 		}
-		URL url= FileLocator.find(bundle, new Path(path), null);
+		URL url = FileLocator.find(bundle, IPath.fromOSString(path), null);
 		if (url != null) {
 			InputStream in = url.openStream();
 			UAElement extension = reader.read(in);

--- a/org.eclipse.help/src/org/eclipse/help/internal/toc/DocumentFinder.java
+++ b/org.eclipse.help/src/org/eclipse/help/internal/toc/DocumentFinder.java
@@ -28,7 +28,6 @@ import java.util.zip.ZipFile;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.util.ResourceLocator;
 import org.osgi.framework.Bundle;
@@ -54,12 +53,12 @@ public class DocumentFinder {
 			directory = ""; //$NON-NLS-1$
 		}
 		// Find doc.zip file
-		IPath iPath = new Path("$nl$/doc.zip"); //$NON-NLS-1$
+		IPath iPath = IPath.fromOSString("$nl$/doc.zip"); //$NON-NLS-1$
 		Map<String, String> override = new HashMap<>(1);
 		override.put("$nl$", locale); //$NON-NLS-1$
 		URL url = FileLocator.find(pluginDesc, iPath, override);
 		if (url == null) {
-			url = FileLocator.find(pluginDesc, new Path("doc.zip"), null); //$NON-NLS-1$
+			url = FileLocator.find(pluginDesc, IPath.fromOSString("doc.zip"), null); //$NON-NLS-1$
 		}
 		if (url != null) {
 			// collect topics from doc.zip file

--- a/org.eclipse.help/src/org/eclipse/help/internal/toc/HrefUtil.java
+++ b/org.eclipse.help/src/org/eclipse/help/internal/toc/HrefUtil.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.help.internal.toc;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 public class HrefUtil {
 	private static final String PLUGINS_ROOT_SLASH = "PLUGINS_ROOT/"; //$NON-NLS-1$
@@ -126,7 +126,7 @@ public class HrefUtil {
 	 */
 	public static String normalizeDirectoryPath(String href) {
 		if (href != null) {
-			return new Path(href).toString();
+			return IPath.fromOSString(href).toString();
 		}
 		return null;
 	}

--- a/org.eclipse.help/src/org/eclipse/help/internal/util/ResourceLocator.java
+++ b/org.eclipse.help/src/org/eclipse/help/internal/util/ResourceLocator.java
@@ -34,7 +34,6 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionDelta;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.IHelpContentProducer;
 import org.eclipse.help.internal.HelpPlugin;
@@ -297,7 +296,7 @@ public class ResourceLocator {
 			Object cached = cache.get(pluginID + '/' + pathPrefix.get(i) + zip);
 			if (cached == null) {
 				try {
-					URL url = FileLocator.find(pluginDesc, new Path(pathPrefix.get(i) + zip), null);
+					URL url = FileLocator.find(pluginDesc, IPath.fromOSString(pathPrefix.get(i) + zip), null);
 					if (url != null) {
 						URL realZipURL = FileLocator.toFileURL(FileLocator.resolve(url));
 						cached = realZipURL.toExternalForm();
@@ -349,7 +348,7 @@ public class ResourceLocator {
 	public static InputStream openFromPlugin(Bundle pluginDesc, String file, String locale) {
 
 		ArrayList<String> pathPrefix = getPathPrefix(locale);
-		URL flatFileURL = find(pluginDesc, new Path(file), pathPrefix);
+		URL flatFileURL = find(pluginDesc, IPath.fromOSString(file), pathPrefix);
 		if (flatFileURL != null)
 			try {
 				return flatFileURL.openStream();
@@ -369,7 +368,7 @@ public class ResourceLocator {
 
 		// try to find the actual file.
 		for (int i = 0; i < pathPrefix.size(); i++) {
-			URL url = FileLocator.find(pluginDesc, new Path(pathPrefix.get(i) + flatFilePath), null);
+			URL url = FileLocator.find(pluginDesc, IPath.fromOSString(pathPrefix.get(i) + flatFilePath), null);
 			if (url != null)
 				return url;
 		}
@@ -472,7 +471,7 @@ public class ResourceLocator {
 		try {
 			ArrayList<String> pathPrefix = ResourceLocator.getPathPrefix(locale);
 			Bundle bundle = Platform.getBundle(pluginId);
-			URL rawURL = ResourceLocator.find(bundle, new Path(file), pathPrefix);
+			URL rawURL = ResourceLocator.find(bundle, IPath.fromOSString(file), pathPrefix);
 			URL resolvedURL = FileLocator.resolve(rawURL);
 			resolvedPath += ", URL = " + resolvedURL.toExternalForm(); //$NON-NLS-1$
 		} catch (Exception e) {

--- a/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/TolerateTest.java
+++ b/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/TolerateTest.java
@@ -16,8 +16,8 @@ package org.eclipse.ua.tests.cheatsheet.parser;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheetParser;
 import org.eclipse.ui.internal.cheatsheets.data.ICheatSheet;
 import org.junit.Assert;
@@ -31,7 +31,7 @@ import org.osgi.framework.FrameworkUtil;
 public class TolerateTest {
 
 	private void parseCheatsheet(String file) {
-		Path path = new Path("data/cheatsheet/valid/tolerate/" + file);
+		IPath path = IPath.fromOSString("data/cheatsheet/valid/tolerate/" + file);
 		URL url = FileLocator.find(FrameworkUtil.getBundle(TolerateTest.class), path, null);
 		CheatSheetParser parser = new CheatSheetParser();
 		ICheatSheet sheet = parser.parse(url, FrameworkUtil.getBundle(getClass()).getSymbolicName(),

--- a/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/ValidTest.java
+++ b/org.eclipse.ua.tests/cheatsheet/org/eclipse/ua/tests/cheatsheet/parser/ValidTest.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.ua.tests.cheatsheet.util.CheatSheetModelSerializer;
 import org.eclipse.ua.tests.util.FileUtil;
 import org.eclipse.ui.internal.cheatsheets.data.CheatSheet;
@@ -34,7 +34,7 @@ import org.osgi.framework.FrameworkUtil;
 public class ValidTest {
 
 	private void parseCheatsheet(String file) throws IOException {
-		Path path = new Path("data/cheatsheet/valid/" + file);
+		IPath path = IPath.fromOSString("data/cheatsheet/valid/" + file);
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 		URL url = FileLocator.find(bundle, path, null);
 		CheatSheetParser parser = new CheatSheetParser();

--- a/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/PrebuiltIndexCompatibility.java
+++ b/org.eclipse.ua.tests/help/org/eclipse/ua/tests/help/search/PrebuiltIndexCompatibility.java
@@ -33,8 +33,8 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.help.internal.base.BaseHelpSystem;
 import org.eclipse.help.internal.search.AnalyzerDescriptor;
 import org.eclipse.help.internal.search.PluginIndex;
@@ -117,7 +117,7 @@ public class PrebuiltIndexCompatibility {
 	 */
 	private void checkReadable(String indexPath) throws IOException,
 			CorruptIndexException {
-		Path path = new Path(indexPath);
+		IPath path = IPath.fromOSString(indexPath);
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 		URL url = FileLocator.find(bundle, path, null);
 		URL resolved = FileLocator.resolve(url);

--- a/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.cheatsheets/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Export-Package: org.eclipse.ui.cheatsheets,
  org.eclipse.ui.internal.cheatsheets.views;x-friends:="org.eclipse.ua.tests",
  org.eclipse.ui.internal.provisional.cheatsheets;x-friends:="org.eclipse.ua.tests"
 Require-Bundle: org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.help.ui;bundle-version="[4.0.0,5.0.0)";resolution:=optional
+ org.eclipse.help.ui;bundle-version="[4.6.0,5.0.0)";resolution:=optional
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/CheatSheetPlugin.java
@@ -30,7 +30,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.help.internal.entityresolver.LocalEntityResolver;
@@ -68,7 +67,7 @@ public class CheatSheetPlugin extends AbstractUIPlugin {
 	private static final String VERSION_STRING[] = { "0.0", "3.0.0" }; //$NON-NLS-1$ //$NON-NLS-2$
 	private static final String MEMENTO_TAG_CHEATSHEET_HISTORY = "cheatsheetHistory"; //$NON-NLS-1$
 
-	public static final IPath ICONS_PATH = new Path("$nl$/icons/"); //$NON-NLS-1$
+	public static final IPath ICONS_PATH = IPath.fromOSString("$nl$/icons/"); //$NON-NLS-1$
 	public static final String T_OBJ = "obj16/"; //$NON-NLS-1$
 	public static final String T_ELCL = "elcl16/"; //$NON-NLS-1$
 	public static final String T_DLCL = "dlcl16/"; //$NON-NLS-1$

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/explorer/TreeLabelProvider.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.SWT;
@@ -188,7 +188,7 @@ public class TreeLabelProvider extends LabelProvider {
 
 	private ImageDescriptor createImageDescriptor(String relativePath) {
 		Bundle bundle = CheatSheetPlugin.getPlugin().getBundle();
-		URL url = FileLocator.find(bundle, new Path(relativePath),null);
+		URL url = FileLocator.find(bundle, IPath.fromOSString(relativePath), null);
 		if (url == null) return null;
 		try {
 			url = FileLocator.resolve(url);

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/model/AbstractTask.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/model/AbstractTask.java
@@ -21,7 +21,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.internal.cheatsheets.composite.parser.ITaskParseStrategy;
 import org.eclipse.ui.internal.provisional.cheatsheets.ICompositeCheatSheet;
@@ -194,7 +194,7 @@ public abstract class AbstractTask implements ICompositeCheatSheetTask {
 			String relativePath = path.substring(index + 1);
 			Bundle bundle = Platform.getBundle(bundleName);
 			if (bundle != null) {
-				return FileLocator.find(bundle, new Path(relativePath), null);
+				return FileLocator.find(bundle, IPath.fromOSString(relativePath), null);
 			}
 		}
 		return new URL(model.getContentUrl(), path);

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/views/TaskEditorManager.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/views/TaskEditorManager.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.osgi.util.NLS;
@@ -79,7 +79,7 @@ public class TaskEditorManager {
 			CheatSheetRegistryReader.getInstance().findTaskEditor(editorKind);
 		if (editorInfo != null) {
 			Bundle bundle = Platform.getBundle(editorInfo.getPluginId());
-			URL url = FileLocator.find(bundle, new Path(editorInfo.getIconPath()), null);
+			URL url = FileLocator.find(bundle, IPath.fromOSString(editorInfo.getIconPath()), null);
 			if (url != null) {
 				try {
 					url = FileLocator.resolve(url);

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/views/TaskExplorerManager.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/composite/views/TaskExplorerManager.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.osgi.util.NLS;
@@ -90,7 +90,7 @@ private static TaskExplorerManager instance;
 			return null;
 		}
 		Bundle bundle = Platform.getBundle(explorerInfo.getPluginId());
-		URL url = FileLocator.find(bundle, new Path(iconPath), null);
+		URL url = FileLocator.find(bundle, IPath.fromOSString(iconPath), null);
 		try {
 			url = FileLocator.resolve(url);
 			return ImageDescriptor.createFromURL(url);

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/data/CheatSheetSaveHelper.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/data/CheatSheetSaveHelper.java
@@ -26,7 +26,6 @@ import javax.xml.parsers.DocumentBuilder;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.IMemento;
@@ -155,12 +154,12 @@ public class CheatSheetSaveHelper {
 		}
 	}
 
-	public Path getStateFile(String csID) {
+	public IPath getStateFile(String csID) {
 		return getStateFile(csID, savePath);
 	}
 
-	protected Path getStateFile(String csID, IPath rootPath) {
-		return new Path(rootPath.append(csID + ".xml").toOSString()); //$NON-NLS-1$
+	protected IPath getStateFile(String csID, IPath rootPath) {
+		return IPath.fromOSString(rootPath.append(csID + ".xml").toOSString()); //$NON-NLS-1$
 	}
 
 	// Attempts to read an xml file from the provided url. Returns a Dom

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/dialogs/CheatSheetCategoryBasedSelectionDialog.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/dialogs/CheatSheetCategoryBasedSelectionDialog.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -367,7 +366,7 @@ public class CheatSheetCategoryBasedSelectionDialog extends TrayDialog //extends
 			fileDlg.open();
 			String filename = fileDlg.getFileName();
 			if (filename != null) {
-				IPath folderPath = new Path(fileDlg.getFilterPath());
+				IPath folderPath = IPath.fromOSString(fileDlg.getFilterPath());
 				IPath filePath = folderPath.append(filename);
 				selectFileCombo.setText(filePath.toOSString());
 				checkRadioButtons();
@@ -453,7 +452,7 @@ public class CheatSheetCategoryBasedSelectionDialog extends TrayDialog //extends
 
 		for (String expandedCategoryPath : expandedCategoryPaths) {
 			CheatSheetCollectionElement category = cheatsheetCategories
-					.findChildCollection(new Path(expandedCategoryPath));
+					.findChildCollection(IPath.fromOSString(expandedCategoryPath));
 			if (category != null) // ie.- it still exists
 				categoriesToExpand.add(category);
 		}
@@ -582,7 +581,7 @@ public class CheatSheetCategoryBasedSelectionDialog extends TrayDialog //extends
 
 	private void setResultFromFile() {
 		// Use the filename without extension as the id of this cheatsheet
-		IPath filePath = new Path(selectFileCombo.getText());
+		IPath filePath = IPath.fromOSString(selectFileCombo.getText());
 		String id = filePath.lastSegment();
 		int extensionIndex = id.indexOf('.');
 		if (extensionIndex > 0) {
@@ -612,7 +611,7 @@ public class CheatSheetCategoryBasedSelectionDialog extends TrayDialog //extends
 
 	private void setResultFromUrl() {
 		// Use the filename without extension as the id of this cheatsheet
-		IPath filePath = new Path(selectUrlCombo.getText());
+		IPath filePath = IPath.fromOSString(selectUrlCombo.getText());
 		String id = filePath.lastSegment();
 		if (id == null) {
 			id = ""; //$NON-NLS-1$

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/registry/CheatSheetCollectionElement.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/registry/CheatSheetCollectionElement.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.IPluginContribution;
 import org.eclipse.ui.internal.cheatsheets.ICheatSheetResource;
@@ -146,7 +145,7 @@ public class CheatSheetCollectionElement extends WorkbenchAdapter implements IPl
 	 */
 	public IPath getPath() {
 		if (parent == null)
-			return new Path(ICheatSheetResource.EMPTY_STRING);
+			return IPath.fromOSString(ICheatSheetResource.EMPTY_STRING);
 
 		return parent.getPath().append(name);
 	}

--- a/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
+++ b/org.eclipse.ui.cheatsheets/src/org/eclipse/ui/internal/cheatsheets/views/CheatSheetViewer.java
@@ -28,8 +28,8 @@ import java.util.Properties;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.help.ui.internal.views.HelpTray;
@@ -1163,7 +1163,7 @@ public class CheatSheetViewer implements ICheatSheetViewer, IMenuContributor {
 				// do nothing
 			}
 		if (bundle != null) {
-			contentURL = FileLocator.find(bundle, new Path(element.getContentFile()), null);
+			contentURL = FileLocator.find(bundle, IPath.fromOSString(element.getContentFile()), null);
 			if (contentURL == null && element.getContentFile() != null) {
 				errorMessage = NLS.bind(Messages.ERROR_OPENING_FILE_IN_PARSER, (new Object[] {element.getContentFile()}));
 			}

--- a/org.eclipse.ui.intro.universal/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.intro.universal/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Export-Package: org.eclipse.ui.internal.intro.universal;x-friends:="org.eclipse.
  org.eclipse.ui.internal.intro.universal.contentdetect;x-friends:="org.eclipse.ua.tests",
  org.eclipse.ui.internal.intro.universal.util;x-internal:=true,
  org.eclipse.ui.intro.universal
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.intro;bundle-version="[3.4.0,4.0.0)"

--- a/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/PageData.java
+++ b/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/PageData.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.ui.intro.config.IntroElement;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -74,7 +73,7 @@ public class PageData {
 		for (int i=0; i<groups.size(); i++) {
 			GroupData gdata = groups.get(i);
 			if (gdata.contains(extensionId)) {
-				IPath resolvedPath = new Path(id);
+				IPath resolvedPath = IPath.fromOSString(id);
 				resolvedPath = resolvedPath.append(gdata.getPath());
 				resolvedPath = resolvedPath.append(extensionId);
 				return resolvedPath.toString();
@@ -87,7 +86,7 @@ public class PageData {
 		for (int i=0; i<groups.size(); i++) {
 			GroupData gdata = groups.get(i);
 			if (gdata.isDefault()) {
-				IPath resolvedPath = new Path(id).append(gdata.getPath());
+				IPath resolvedPath = IPath.fromOSString(id).append(gdata.getPath());
 				resolvedPath = resolvedPath.append(IUniversalIntroConstants.DEFAULT_ANCHOR);
 				return resolvedPath.toString();
 			}
@@ -104,7 +103,7 @@ public class PageData {
 			return hidden;
 		for (int i=0; i<groups.size(); i++) {
 			GroupData gdata = groups.get(i);
-			IPath path = new Path(gdata.getPath());
+			IPath path = IPath.fromOSString(gdata.getPath());
 			if (path.lastSegment().equals(groupId))
 				return gdata;
 		}

--- a/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
+++ b/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/UniversalIntroConfigurer.java
@@ -26,7 +26,6 @@ import java.util.StringTokenizer;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.util.ProductPreferences;
 import org.eclipse.help.internal.util.SequenceResolver;
@@ -225,7 +224,7 @@ public class UniversalIntroConfigurer extends IntroConfigurer implements
 		if (prefix.length() == 0) {
 			return null;
 		}
-		return prefix + Path.SEPARATOR + path;
+		return prefix + IPath.SEPARATOR + path;
 	}
 
 	private String getProductProperty(IProduct product, String variableName) {
@@ -606,7 +605,7 @@ public class UniversalIntroConfigurer extends IntroConfigurer implements
 	@Override
 	public String resolvePath(String extensionId, String path) {
 		boolean extensionRelativePath = false;
-		IPath ipath = new Path(path);
+		IPath ipath = IPath.fromOSString(path);
 		String pageId = ipath.segment(0);
 		String s2 = ipath.segment(1);
 		// if it's "@extension_id" then target that extension instead
@@ -621,7 +620,7 @@ public class UniversalIntroConfigurer extends IntroConfigurer implements
 			if (resolvedPath != null) {
 				if (extensionRelativePath) {
 					// not done - use the resolved extension path to complete the source path
-					IPath p2 = new Path(resolvedPath);
+					IPath p2 = IPath.fromOSString(resolvedPath);
 					IPath p1 = ipath.removeFirstSegments(2);
 					// remove the last anchor and append the relative path from the extension
 					resolvedPath = p2.removeLastSegments(1).append(p1).toString();

--- a/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/BundleUtil.java
+++ b/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/BundleUtil.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
@@ -121,7 +120,7 @@ public class BundleUtil {
 		if (resource == null)
 			return null;
 
-		String fullResource = new Path(base).append(resource).toString();
+		String fullResource = IPath.fromOSString(base).append(resource).toString();
 		String resolvedResource = getResolvedResourceLocation(fullResource,
 			bundle, true);
 
@@ -151,7 +150,7 @@ public class BundleUtil {
 					copyResource = resource.substring(1);
 				copyResource = NL_TAG + copyResource;
 			}
-			IPath resourcePath = new Path(copyResource);
+			IPath resourcePath = IPath.fromOSString(copyResource);
 			localLocation = FileLocator.find(bundle, resourcePath, null);
 			if (localLocation == null) {
 				// localLocation can be null if the passed resource could not
@@ -205,9 +204,7 @@ public class BundleUtil {
 	 */
 	public static URL getResourceAsURL(String resource, String pluginId) {
 		Bundle bundle = Platform.getBundle(pluginId);
-		URL localLocation = FileLocator.find(bundle, new Path(
-			resource), null);
-		return localLocation;
+		return FileLocator.find(bundle, IPath.fromOSString(resource), null);
 	}
 
 

--- a/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/ImageUtil.java
+++ b/org.eclipse.ui.intro.universal/src/org/eclipse/ui/internal/intro/universal/util/ImageUtil.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -87,7 +86,7 @@ public final class ImageUtil {
 	public static ImageDescriptor createImageDescriptor(Bundle bundle,
 			String imageName) {
 		try {
-			URL imageUrl = FileLocator.find(bundle, new Path(imageName), null);
+			URL imageUrl = FileLocator.find(bundle, IPath.fromOSString(imageName), null);
 			if (imageUrl != null) {
 				ImageDescriptor desc = ImageDescriptor.createFromURL(imageUrl);
 				return desc;

--- a/org.eclipse.ui.intro/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.intro/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Export-Package: org.eclipse.ui.internal.intro.impl;x-friends:="org.eclipse.ui.in
  org.eclipse.ui.internal.intro.impl.util;x-friends:="org.eclipse.ua.tests",
  org.eclipse.ui.intro.config,
  org.eclipse.ui.intro.contentproviders
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.help.base;bundle-version="[4.0.0,5.0.0)";resolution:=optional,
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroPage.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/AbstractIntroPage.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Vector;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.help.internal.UAElement;
 import org.eclipse.help.internal.UAElementFactory;
@@ -151,7 +150,7 @@ public abstract class AbstractIntroPage extends AbstractIntroContainer {
 			// the base of this page to be relative to the new xml file
 			// location.
 			IPath subBase = ModelUtil.getParentFolderPath(content);
-			this.base = new Path(base).append(subBase).toString();
+			this.base = IPath.fromOSString(base).append(subBase).toString();
 			content = BundleUtil.getResolvedResourceLocation(base, content,
 				bundle);
 		}

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/IntroExtensionContent.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/IntroExtensionContent.java
@@ -21,7 +21,6 @@ import java.util.Vector;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.ui.internal.intro.impl.model.loader.IntroContentParser;
 import org.eclipse.ui.internal.intro.impl.model.util.BundleUtil;
 import org.eclipse.ui.internal.intro.impl.model.util.ModelUtil;
@@ -84,7 +83,7 @@ public class IntroExtensionContent extends AbstractIntroElement {
 			// not this xml file, point the base of this page to be relative to
 			// the new xml file location.
 			IPath subBase = ModelUtil.getParentFolderPath(content);
-			String newBase = new Path(base).append(subBase).toString();
+			String newBase = IPath.fromOSString(base).append(subBase).toString();
 			extractFileAndId(bundle);
 			contentFile = BundleUtil.getResolvedResourceLocation(base, contentFile,
 				bundle);
@@ -264,7 +263,7 @@ public class IntroExtensionContent extends AbstractIntroElement {
 	 */
 	private void extractFileAndId(Bundle bundle) {
 		// look for the file
-		IPath resourcePath = new Path(base + content);
+		IPath resourcePath = IPath.fromOSString(base + content);
 		if (FileLocator.find(bundle, resourcePath, null) != null) {
 			// found it, assume it's a file
 			contentFile = content;

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/IntroModelRoot.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/IntroModelRoot.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.ListenerList;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.help.UAContentFilter;
@@ -649,7 +648,7 @@ public class IntroModelRoot extends AbstractIntroContainer {
 		String extensionId = extensionContent.getId();
 		// if this is a replace, take the mixin style as what is being replaced
 		if (extensionContent.getExtensionType() == IntroExtensionContent.TYPE_REPLACEMENT) {
-			IPath ipath = new Path(extensionContent.getPath());
+			IPath ipath = IPath.fromOSString(extensionContent.getPath());
 			String s2 = ipath.segment(1);
 			if (s2 != null && s2.startsWith("@") && s2.length() > 1) { //$NON-NLS-1$
 				extensionId = s2.substring(1);

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/BundleUtil.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/BundleUtil.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.internal.intro.impl.util.Log;
 import org.eclipse.ui.internal.intro.impl.util.StringUtil;
@@ -124,7 +123,7 @@ public class BundleUtil {
 		if (resource == null)
 			return null;
 
-		String fullResource = new Path(base).append(resource).toString();
+		String fullResource = IPath.fromOSString(base).append(resource).toString();
 		String resolvedResource = getResolvedResourceLocation(fullResource,
 			bundle, true);
 
@@ -178,7 +177,7 @@ public class BundleUtil {
 					copyResource = resource.substring(1);
 				copyResource = NL_TAG + copyResource;
 			}
-			IPath resourcePath = new Path(copyResource);
+			IPath resourcePath = IPath.fromOSString(copyResource);
 			localLocation = FileLocator.find(bundle, resourcePath, null);
 			if (localLocation == null) {
 				// localLocation can be null if the passed resource could not
@@ -211,9 +210,7 @@ public class BundleUtil {
 	 */
 	public static URL getResourceAsURL(String resource, String pluginId) {
 		Bundle bundle = Platform.getBundle(pluginId);
-		URL localLocation = FileLocator.find(bundle, new Path(
-			resource), null);
-		return localLocation;
+		return FileLocator.find(bundle, IPath.fromOSString(resource), null);
 	}
 
 

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/FindSupport.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/FindSupport.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
 
@@ -32,9 +31,9 @@ public class FindSupport {
 
 	private static String[] buildNLVariants(String nl) {
 		ArrayList<String> result = new ArrayList<>();
-		IPath base = new Path("nl"); //$NON-NLS-1$
+		IPath base = IPath.fromOSString("nl"); //$NON-NLS-1$
 
-		IPath path = new Path(nl.replace('_', '/'));
+		IPath path = IPath.fromOSString(nl.replace('_', '/'));
 		while (path.segmentCount() > 0) {
 			result.add(base.append(path).toString());
 			// for backwards compatibility only, don't replace the slashes
@@ -103,9 +102,9 @@ public class FindSupport {
 			// Watch for the root case.  It will produce a new
 			// URL which is only the root directory (and not the
 			// root of this plugin).
-			result = findInPlugin(b, Path.EMPTY, multiple);
+			result = findInPlugin(b, IPath.EMPTY, multiple);
 			if (result == null || multiple != null)
-				result = findInFragments(b, Path.EMPTY, multiple);
+				result = findInFragments(b, IPath.EMPTY, multiple);
 			return result;
 		}
 
@@ -155,7 +154,7 @@ public class FindSupport {
 			return null;
 
 		URL result = null;
-		IPath base = new Path("os").append(os).append(osArch); //$NON-NLS-1$
+		IPath base = IPath.fromOSString("os").append(os).append(osArch); //$NON-NLS-1$
 		// Keep doing this until all you have left is "os" as a path
 		while (base.segmentCount() != 1) {
 			IPath filePath = base.append(path);
@@ -183,7 +182,7 @@ public class FindSupport {
 		if (ws == null)
 			// use default
 			ws = Platform.getWS();
-		IPath filePath = new Path("ws").append(ws).append(path); //$NON-NLS-1$
+		IPath filePath = IPath.fromOSString("ws").append(ws).append(path); //$NON-NLS-1$
 		// We know that there is only one segment to the ws path
 		// e.g. ws/win32
 		URL result = findInPlugin(b, filePath, multiple);
@@ -212,7 +211,7 @@ public class FindSupport {
 
 		URL result = null;
 		for (int i = 0; i < nlVariants.length; i++) {
-			IPath filePath = new Path(nlVariants[i]).append(path);
+			IPath filePath = IPath.fromOSString(nlVariants[i]).append(path);
 			result = findInPlugin(b, filePath, multiple);
 			if (result != null && multiple == null)
 				return result;

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/ModelUtil.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/model/util/ModelUtil.java
@@ -21,7 +21,6 @@ import java.util.Vector;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.internal.intro.impl.model.AbstractIntroPage;
 import org.eclipse.ui.internal.intro.impl.model.IntroExtensionContent;
@@ -159,7 +158,7 @@ public class ModelUtil {
 	 * Returns the parent folder of the given path.
 	 */
 	public static IPath getParentFolderPath(String contentFilePath) {
-		IPath path = new Path(contentFilePath);
+		IPath path = IPath.fromOSString(contentFilePath);
 		path = path.removeLastSegments(1).addTrailingSeparator();
 		return path;
 	}

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/swt/PageStyleManager.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/swt/PageStyleManager.java
@@ -19,7 +19,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
@@ -538,7 +538,7 @@ public class PageStyleManager extends SharedStyleManager {
 			}
 		}
 		Bundle bundle = introImage.getBundle();
-		if (FileLocator.find(bundle, new Path(imageLocation), null) == null) {
+		if (FileLocator.find(bundle, IPath.fromOSString(imageLocation), null) == null) {
 			return null;
 		}
 		ImageUtil.registerImage(key, bundle, imageLocation);

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/swt/SharedStyleManager.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/swt/SharedStyleManager.java
@@ -18,7 +18,6 @@ import java.net.URL;
 import java.util.Properties;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
@@ -70,7 +69,7 @@ public class SharedStyleManager {
 			try (InputStream is = styleURL.openStream()) {
 				properties.load(is);
 			}
-			context.path = new Path(style).removeLastSegments(1);
+			context.path = IPath.fromOSString(style).removeLastSegments(1);
 			String t = (String)properties.get("theme"); //$NON-NLS-1$
 			if (t!=null && t.trim().equalsIgnoreCase("true")) //$NON-NLS-1$
 				context.inTheme = true;

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/util/ImageUtil.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/internal/intro/impl/util/ImageUtil.java
@@ -17,7 +17,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
@@ -73,7 +72,7 @@ public final class ImageUtil {
 	public static ImageDescriptor createImageDescriptor(Bundle bundle,
 			String imageName) {
 		try {
-			URL imageUrl = FileLocator.find(bundle, new Path(imageName), null);
+			URL imageUrl = FileLocator.find(bundle, IPath.fromOSString(imageName), null);
 			if (imageUrl != null) {
 				ImageDescriptor desc = ImageDescriptor.createFromURL(imageUrl);
 				return desc;

--- a/org.eclipse.ui.intro/src/org/eclipse/ui/intro/contentproviders/EclipseRSSViewer.java
+++ b/org.eclipse.ui.intro/src/org/eclipse/ui/intro/contentproviders/EclipseRSSViewer.java
@@ -35,7 +35,6 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.osgi.util.NLS;
@@ -213,7 +212,7 @@ public class EclipseRSSViewer implements IIntroContentProvider {
 					doNavigate((String) e.getHref());
 				}
 			});
-			bulletImage = createImage(new Path("icons/arrow.png")); //$NON-NLS-1$
+			bulletImage = createImage(IPath.fromOSString("icons/arrow.png")); //$NON-NLS-1$
 			if (bulletImage != null)
 				formText.setImage(HREF_BULLET, bulletImage);
 			this.parent = parent;


### PR DESCRIPTION
Use the new `IPath` factory methods introduced in https://github.com/eclipse-equinox/equinox/pull/228 in Platform-UA.

With this PR `org.eclipse.core.runtime.Path` is not referenced anymore in Platform-UA's entire code base.